### PR TITLE
fix(Navbar): hovering over title does not change cursor

### DIFF
--- a/src/components/Hero/Minimal/navbar.tsx
+++ b/src/components/Hero/Minimal/navbar.tsx
@@ -15,7 +15,7 @@ const Navbar: React.FC<Props> = ({ title, theme, isDarkMode, handleDarkModeClick
       <div className={`bg-${theme.primary} h-2`}></div>
       <nav className={`container mx-auto py-8 flex`}>
         <div className="px-4 flex">
-          <span className={`font-bold text-lg tracking-tight text-${theme.primary}`}>{title}</span>
+          <span className={`font-bold text-lg tracking-tight text-${theme.primary} cursor-default`}>{title}</span>
         </div>
         <div className="flex-grow"></div>
         <div className={`flex px-4 text-${theme.primary}`}>

--- a/src/components/Hero/Simple/navbar.tsx
+++ b/src/components/Hero/Simple/navbar.tsx
@@ -14,7 +14,7 @@ const Navbar: React.FC<Props> = ({ title, isDarkMode, handleDarkModeClick }) => 
     <div>
       <nav className={`container mx-auto py-8 flex`}>
         <div className="px-4 flex">
-          <span className={`font-bold text-lg tracking-tight text-gray-100`}>{title}</span>
+          <span className={`font-bold text-lg tracking-tight text-gray-100 cursor-default`}>{title}</span>
         </div>
         <div className="flex-grow"></div>
         <div className={`flex px-4 text-gray-100`}>


### PR DESCRIPTION
It was ugly when it changed the cursor to the text version instead of just leaving it as default for when something is not clickable.